### PR TITLE
Little error in the main file of the example

### DIFF
--- a/examples/jakstat_signaling/mainJakstatSignaling.m
+++ b/examples/jakstat_signaling/mainJakstatSignaling.m
@@ -158,7 +158,7 @@ end
     
 % Run getMultiStarts
 fprintf('\n Perform optimization...');
-parametersMultistart = getMultiStarts(parameters, objectiveFunction, optionsPesto);
+parameters = getMultiStarts(parameters, objectiveFunction, optionsPesto);
 % parametersHybrid = getMultiStarts(parameters, objectiveFunction, optionsPestoHybrid);
 % parametersGlobal = getMultiStarts(parameters, objectiveFunction, optionsPestoGlobal);
 


### PR DESCRIPTION
Fixed the name of the parameter struct, since profiling fails otherwise.