### PR TITLE
Fix multistart failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ doc/config/mtocpp_filter.sh
 DRAMToolbox
 *.asv
 examples/RAmPART_examples/results
+*ess_report.mat

--- a/getMultiStarts.m
+++ b/getMultiStarts.m
@@ -316,23 +316,32 @@ if strcmp(options.comp_type, 'sequential')
                 warning(['Multi-start number ' num2str(iMS) ' failed. More details on the error:']);
                 display(['Last Error in function ' ErrMsg.stack(1).name ', line ' ...
                     num2str(ErrMsg.stack(1).line) ', file ' ErrMsg.stack(1).file '.']);
+                
+                % Assign values to exitflag, gradient etc. to avoid
+                % failure when assigning results
+                exitflag       = nan;
+                n_objfun       = nan;
+                n_iter         = nan;
+                negLogPost_opt = nan;
+                par_opt        = nan(size(freePars));
+                hessian_opt    = nan(length(freePars));
             end
             
-        end
-        
-        % Assignment of results
-        parameters.MS.t_cpu(iMS) = cputime - startTimeLocalOptimization;
-        parameters.MS.exitflag(iMS) = exitflag;
-        parameters.MS.logPost0(iMS) = -negLogPost0;
-        parameters.MS.logPost(iMS) = -negLogPost_opt;
-        parameters.MS.par(:,iMS) = par_opt;
-        parameters.MS.gradient(freePars,iMS) = gradient_opt(:);
-        parameters.MS.hessian(freePars,freePars,iMS) = hessian_opt(:,:);
-        parameters.MS.n_objfun(iMS) = n_objfun;
-        parameters.MS.n_iter(iMS) = n_iter;
-        parameters.MS.AIC(iMS) = 2*length(freePars) + 2*negLogPost_opt;
-        if ~isempty(options.nDatapoints)
-            parameters.MS.BIC(iMS) = log(options.nDatapoints)*length(freePars) + 2*negLogPost_opt;
+            % Assignment of results
+            parameters.MS.t_cpu(iMS) = cputime - startTimeLocalOptimization;
+            parameters.MS.exitflag(iMS) = exitflag;
+            parameters.MS.logPost0(iMS) = -negLogPost0;
+            parameters.MS.logPost(iMS) = -negLogPost_opt;
+            parameters.MS.par(:,iMS) = par_opt;
+            parameters.MS.gradient(freePars,iMS) = gradient_opt(:);
+            parameters.MS.hessian(freePars,freePars,iMS) = hessian_opt(:,:);
+            parameters.MS.n_objfun(iMS) = n_objfun;
+            parameters.MS.n_iter(iMS) = n_iter;
+            parameters.MS.AIC(iMS) = 2*length(freePars) + 2*negLogPost_opt;
+            if ~isempty(options.nDatapoints)
+                parameters.MS.BIC(iMS) = log(options.nDatapoints)*length(freePars) + 2*negLogPost_opt;
+            end
+            
         end
         
         % Save

--- a/getParameterProfiles.m
+++ b/getParameterProfiles.m
@@ -76,9 +76,17 @@ function [parameters,fh] = getParameterProfiles(parameters, objective_function, 
         options = PestoOptions();
     end
 
-    % Check if MultiStart was launched before
+    % Check if MultiStart was launched before and was successful
     if(~isfield(parameters, 'MS'))
         error('No information from optimization available. Please run getMultiStarts() before getParameterProfiles.');
+    end
+    if (isempty(options.MAP_index))
+        options.MAP_index = 1;
+    end
+    if any(isnan([parameters.MS.par(:,options.MAP_index); parameters.MS.logPost(options.MAP_index)]))
+        error(['It seems like the multi-start index from which you want to start a ' ...
+            'profile calculation was not successful. Please check your multi-start ' ...
+            'results and options.MAP_index!']);
     end
                 
     % Check and assign options
@@ -90,9 +98,6 @@ function [parameters,fh] = getParameterProfiles(parameters, objective_function, 
     if (~isfield(options.profileOptimizationOptions, 'MaxFunEvals') ...
                 || isempty(options.profileOptimizationOptions.MaxFunEvals)) 
         options.profileOptimizationOptions.MaxFunEvals = 200 * parameters.number;
-    end
-    if (isempty(options.MAP_index))
-        options.MAP_index = 1;
     end
     
     % Check for emptiness of options


### PR DESCRIPTION
The assignment of results in getMultiStarts could fail, if all multi-starts errored due to a poor guess. Assigning NANs and moving assignment two lines up into the if-else fixes this