### PR TITLE
Option no hessian

### DIFF
--- a/@PestoOptions/PestoOptions.m
+++ b/@PestoOptions/PestoOptions.m
@@ -116,6 +116,12 @@ classdef PestoOptions < matlab.mixin.CustomDisplay
             'MaxIter', 2000, ...
             'PrecondBandWidth', inf);
         
+        % Option for saving the Hessian at optimal parameter values
+        % (As Hessians can be large matrices, they may take a lot of memory
+        % and in some cases computation time, if they are not automatically
+        % computed during optimization)
+        localOptimizerSaveHessian = true;
+        
         % Method used to propose starting points for fmincon. Can be
         % * 'latin hypercube': latin hypercube sampling
         % * 'uniform': uniform random sampling

--- a/getMultiStarts.m
+++ b/getMultiStarts.m
@@ -171,7 +171,11 @@ parameters.MS.par = nan(parameters.number,length(options.start_index));
 parameters.MS.logPost0 = nan(length(options.start_index),1);
 parameters.MS.logPost = nan(length(options.start_index),1);
 parameters.MS.gradient = nan(parameters.number,length(options.start_index));
-parameters.MS.hessian  = nan(parameters.number,parameters.number,length(options.start_index));
+if options.localOptimizerSaveHessian
+    parameters.MS.hessian  = nan(parameters.number,parameters.number,length(options.start_index));
+else
+    parameters.MS.hessian  = nan(0,0,length(options.start_index));
+end
 parameters.MS.n_objfun = nan(length(options.start_index),1);
 parameters.MS.n_iter = nan(length(options.start_index),1);
 parameters.MS.t_cpu = nan(length(options.start_index),1);
@@ -325,7 +329,9 @@ if strcmp(options.comp_type, 'sequential')
                 negLogPost_opt = nan;
                 par_opt        = nan(parameters.number,1);
                 gradient_opt   = nan(length(freePars),1);
-                hessian_opt    = nan(length(freePars));
+                if options.localOptimizerSaveHessian
+                    hessian_opt    = nan(length(freePars));
+                end
             end
             
             % Assignment of results
@@ -335,7 +341,9 @@ if strcmp(options.comp_type, 'sequential')
             parameters.MS.logPost(iMS) = -negLogPost_opt;
             parameters.MS.par(:,iMS) = par_opt;
             parameters.MS.gradient(freePars,iMS) = gradient_opt(:);
-            parameters.MS.hessian(freePars,freePars,iMS) = hessian_opt(:,:);
+            if options.localOptimizerSaveHessian
+                parameters.MS.hessian(freePars,freePars,iMS) = hessian_opt(:,:);
+            end
             parameters.MS.n_objfun(iMS) = n_objfun;
             parameters.MS.n_iter(iMS) = n_iter;
             parameters.MS.AIC(iMS) = 2*length(freePars) + 2*negLogPost_opt;

--- a/private/performOptimizationBobyqa.m
+++ b/private/performOptimizationBobyqa.m
@@ -23,17 +23,26 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     par_opt(freePars) = par_opt;
     par_opt(options.fixedParameters) = options.fixedParameterValues;
     
-    % Assignment of gradient and Hessian
+    % Assignment of gradient (and maybe Hessian)
     try
-        [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
-        hessian_opt(freePars,freePars) = hessian_opt;
-        hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        if options.localOptimizerSaveHessian
+            [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
+            hessian_opt(freePars,freePars) = hessian_opt;
+            hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        else
+            [~, gradient_opt] = negLogPost(par_opt);
+            hessian_opt = [];
+        end
         gradient_opt(freePars) = gradient_opt;
         gradient_opt(options.fixedParameters) = nan;
     catch
-        warning('Could not compute Hessian and gradient at optimum after optimization.');
-        if (options.objOutNumber == 3)
-            warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+        if options.localOptimizerSaveHessian
+            warning('Could not compute Hessian and gradient at optimum after optimization.');
+            if (options.objOutNumber == 3)
+                warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+            end
+        else
+            warning('Could not compute gradient at optimum after optimization.');
         end
     end
 

--- a/private/performOptimizationDhc.m
+++ b/private/performOptimizationDhc.m
@@ -23,17 +23,26 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     par_opt(freePars) = par_opt;
     par_opt(options.fixedParameters) = options.fixedParameterValues;
     
-    % Assignment of gradient and Hessian
+    % Assignment of gradient (and maybe Hessian)
     try
-        [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
-        hessian_opt(freePars,freePars) = hessian_opt;
-        hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        if options.localOptimizerSaveHessian
+            [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
+            hessian_opt(freePars,freePars) = hessian_opt;
+            hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        else
+            [~, gradient_opt] = negLogPost(par_opt);
+            hessian_opt = [];
+        end
         gradient_opt(freePars) = gradient_opt;
         gradient_opt(options.fixedParameters) = nan;
     catch
-        warning('Could not compute Hessian and gradient at optimum after optimization.');
-        if (options.objOutNumber == 3)
-            warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+        if options.localOptimizerSaveHessian
+            warning('Could not compute Hessian and gradient at optimum after optimization.');
+            if (options.objOutNumber == 3)
+                warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+            end
+        else
+            warning('Could not compute gradient at optimum after optimization.');
         end
     end
     

--- a/private/performOptimizationFmincon.m
+++ b/private/performOptimizationFmincon.m
@@ -50,12 +50,14 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     par_opt(options.fixedParameters) = options.fixedParameterValues;
     
     % Assignment of gradient and Hessian
-    if isempty(hessian_opt)
-        hessian_opt = nan(numel(freePars));
-    elseif max(hessian_opt(:)) == 0
-        if strcmp(options.localOptimizerOptions.Hessian,'on')
+    if options.localOptimizerSaveHessian
+        if isempty(hessian_opt)
+            hessian_opt = nan(numel(freePars));
+        elseif isempty(find(a,1)) && strcmp(options.localOptimizerOptions.Hessian,'on')
             [~,~,hessian_opt] = negLogPost(par_opt);
         end
+    else
+        hessian_opt = [];
     end
     
 end

--- a/private/performOptimizationFmincon.m
+++ b/private/performOptimizationFmincon.m
@@ -53,7 +53,7 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     if options.localOptimizerSaveHessian
         if isempty(hessian_opt)
             hessian_opt = nan(numel(freePars));
-        elseif isempty(find(a,1)) && strcmp(options.localOptimizerOptions.Hessian,'on')
+        elseif isempty(find(hessian_opt,1)) && strcmp(options.localOptimizerOptions.Hessian,'on')
             [~,~,hessian_opt] = negLogPost(par_opt);
         end
     else

--- a/private/performOptimizationLsqnonlin.m
+++ b/private/performOptimizationLsqnonlin.m
@@ -31,9 +31,15 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     
     % Assigment of Hessian (gradient is not computed)
     gradient_opt = nan(size(par_opt));
-    if ~isempty(jacobian_opt)
-        hessian_sqrt = full(jacobian_opt);
-        hessian_opt = hessian_sqrt' * hessian_sqrt;
+    if options.localOptimizerSaveHessian
+        if ~isempty(jacobian_opt)
+            hessian_sqrt = full(jacobian_opt);
+            hessian_opt = hessian_sqrt' * hessian_sqrt;
+        else
+            hessian_opt = nan(numel(freePars));
+        end
+    else
+        hessian_opt = [];
     end
     
 end

--- a/private/performOptimizationMeigo.m
+++ b/private/performOptimizationMeigo.m
@@ -40,11 +40,20 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     
     % Assignment of gradient and Hessian
     try
-        [~, gradient_opt, hessian_opt] = negLogPost(Results.xbest);
+        if options.localOptimizerSaveHessian
+            [~, gradient_opt, hessian_opt] = negLogPost(Results.xbest);
+        else
+            [~, gradient_opt] = negLogPost(Results.xbest);
+            hessian_opt = [];
+        end
     catch
-        warning('Could not compute Hessian and gradient at optimum after optimization.');
-        if (options.objOutNumber == 3)
-            warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+        if options.localOptimizerSaveHessian
+            warning('Could not compute Hessian and gradient at optimum after optimization.');
+            if (options.objOutNumber == 3)
+                warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+            end
+        else
+            warning('Could not compute gradient at optimum after optimization.');
         end
     end
     

--- a/private/performOptimizationPswarm.m
+++ b/private/performOptimizationPswarm.m
@@ -27,17 +27,26 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     n_iter = RunData.IterCounter;
     par_opt(options.fixedParameters) = options.fixedParameterValues;
     
-    % Assignment of gradient and Hessian
+    % Assignment of gradient (and maybe Hessian)
     try
-        [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
-        hessian_opt(freePars,freePars) = hessian_opt;
-        hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        if options.localOptimizerSaveHessian
+            [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
+            hessian_opt(freePars,freePars) = hessian_opt;
+            hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        else
+            [~, gradient_opt] = negLogPost(par_opt);
+            hessian_opt = [];
+        end
         gradient_opt(freePars) = gradient_opt;
         gradient_opt(options.fixedParameters) = nan;
     catch
-        warning('Could not compute Hessian and gradient at optimum after optimization.');
-        if (options.objOutNumber == 3)
-            warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+        if options.localOptimizerSaveHessian
+            warning('Could not compute Hessian and gradient at optimum after optimization.');
+            if (options.objOutNumber == 3)
+                warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+            end
+        else
+            warning('Could not compute gradient at optimum after optimization.');
         end
     end
                         

--- a/private/performOptimizationRcs.m
+++ b/private/performOptimizationRcs.m
@@ -23,17 +23,26 @@ function [negLogPost_opt, par_opt, gradient_opt, hessian_opt, exitflag, n_objfun
     par_opt(freePars) = par_opt;
     par_opt(options.fixedParameters) = options.fixedParameterValues;
     
-    % Assignment of gradient and Hessian
+    % Assignment of gradient (and maybe Hessian)
     try
-        [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
-        hessian_opt(freePars,freePars) = hessian_opt;
-        hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        if options.localOptimizerSaveHessian
+            [~, gradient_opt, hessian_opt] = negLogPost(par_opt);
+            hessian_opt(freePars,freePars) = hessian_opt;
+            hessian_opt(options.fixedParameters,options.fixedParameters) = nan;
+        else
+            [~, gradient_opt] = negLogPost(par_opt);
+            hessian_opt = [];
+        end
         gradient_opt(freePars) = gradient_opt;
         gradient_opt(options.fixedParameters) = nan;
     catch
-        warning('Could not compute Hessian and gradient at optimum after optimization.');
-        if (options.objOutNumber == 3)
-            warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+        if options.localOptimizerSaveHessian
+            warning('Could not compute Hessian and gradient at optimum after optimization.');
+            if (options.objOutNumber == 3)
+                warning('options.objOutNumber is set to 3, but your objective function can not provide 3 outputs. Please set objOutNumber accordingly!');
+            end
+        else
+            warning('Could not compute gradient at optimum after optimization.');
         end
     end
     


### PR DESCRIPTION
As already discussed, for some optimization methods, it is not natural to have the Hessian computed after optimization, as this must be done separately and takes a lot of time.
On the other hand, when result from optimization are stored, the very most memory goes into the Hessians, which are not always needed.
It hence makes sense to be able to disable storing or computing the Hessian after optimization.