### PR TITLE
Bugfix PT

### DIFF
--- a/@PTOptions/PTOptions.m
+++ b/@PTOptions/PTOptions.m
@@ -232,7 +232,7 @@ classdef PTOptions < matlab.mixin.CustomDisplay
          if(value > 0)
             this.maxT = lower(value);
          else
-            error(['Please enter the maximum temperature. May be inf.']);
+            error(['Please enter the maximum temperature.']);
          end
       end        
             

--- a/@PTOptions/PTOptions.m
+++ b/@PTOptions/PTOptions.m
@@ -38,8 +38,8 @@ classdef PTOptions < matlab.mixin.CustomDisplay
       % Scaling factor for temperature adaptation
       temperatureEta = 100;
       
-      % Maximum T - may be infinity
-      maxT = inf;
+      % Maximum T 
+      maxT = 5e4;
 
    end
    

--- a/@PTOptions/PTOptions.m
+++ b/@PTOptions/PTOptions.m
@@ -15,7 +15,6 @@ classdef PTOptions < matlab.mixin.CustomDisplay
       % velocity of the single-chain proposals.
       % Value between 0 and 1.
       % No adaption (classical Metropolis-Hastings) for 0.
-
       alpha = 0.51;
 
       % Parameter which controlls the adaption degeneration velocity of
@@ -229,7 +228,7 @@ classdef PTOptions < matlab.mixin.CustomDisplay
          end
       end  
       
-      function set.maxT(this, value)
+      function this = set.maxT(this, value)
          if(value > 0)
             this.maxT = lower(value);
          else

--- a/@RAMPARTOptions/RAMPARTOptions.m
+++ b/@RAMPARTOptions/RAMPARTOptions.m
@@ -249,7 +249,7 @@ classdef RAMPARTOptions < matlab.mixin.SetGet
          if(value > 0)
             this.maxT = lower(value);
          else
-            error(['Please enter the maximum temperature. May be inf.']);
+            error(['Please enter the maximum temperature.']);
          end
       end
       

--- a/@RAMPARTOptions/RAMPARTOptions.m
+++ b/@RAMPARTOptions/RAMPARTOptions.m
@@ -38,8 +38,8 @@ classdef RAMPARTOptions < matlab.mixin.SetGet
       % Scaling factor for temperature adaptation
       temperatureEta = 10;
       
-      % Maximum T - may be infinity
-      maxT = inf;
+      % Maximum T
+      maxT = 5e4;
       
       % Fraction of iterations which are used to train a region predictor
       trainPhaseFrac = 0.2;

--- a/examples/HierarchicalOptimization_examples/SmallJakStat/runProfiles_JakStat.m
+++ b/examples/HierarchicalOptimization_examples/SmallJakStat/runProfiles_JakStat.m
@@ -17,6 +17,8 @@ approach = varargin{1};
 distribution = varargin{2};
 if nargin > 2
     MAP_index = varargin{3};
+else
+    MAP_index = 1;
 end
 
 load('data/data_JakStat.mat')


### PR DESCRIPTION
- maxT was default set to inf, but needs to be finite for the Vousden scheme
- maxT could not be changed 

minor Hierarchical Optimization example bugfix: 
- set MAP_index to 1 if not provided for runProfiles